### PR TITLE
Update Kotest to 5.8.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Advent of Code - Kotlin (AocKt)
 
 [![Kotlin](https://img.shields.io/badge/Kotlin-1.9.23-%237F52FF.svg?style=flat-square&logo=kotlin&logoColor=%237F52FF)](https://kotlinlang.org/)
-[![Kotest](https://img.shields.io/badge/Kotest-5.7.2-%35ED35.svg?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiI+PHBhdGggc3R5bGU9ImZpbGw6IzM1ZWQzNSIgZD0iTTEyIDJoNGwtOCA4IDQgNEg0di00TDAgNmg4WiIvPjwvc3ZnPg==)](https://kotest.io/)
+[![Kotest](https://img.shields.io/badge/Kotest-5.8.1-%35ED35.svg?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiI+PHBhdGggc3R5bGU9ImZpbGw6IzM1ZWQzNSIgZD0iTTEyIDJoNGwtOCA4IDQgNEg0di00TDAgNmg4WiIvPjwvc3ZnPg==)](https://kotest.io/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/Jadarma/advent-of-code-kotlin/build.yml?style=flat-square&logo=github&label=Build&logoColor=%23171515)](https://github.com/Jadarma/advent-of-code-kotlin/actions/workflows/build.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.jadarma.aockt/aockt-test?style=flat-square&color=blue&logo=apachemaven&logoColor=blue&label=Maven%20Central)](https://central.sonatype.com/namespace/io.github.jadarma.aockt)
 [![Snapshot](https://img.shields.io/nexus/s/io.github.jadarma.aockt/aockt-test?server=https%3A%2F%2Fs01.oss.sonatype.org&style=flat-square&color=orange&logo=apachemaven&logoColor=orange&label=Snapshot)](https://s01.oss.sonatype.org/content/repositories/snapshots/io/github/jadarma/aockt/)
@@ -34,7 +34,7 @@ repositories {
 dependencies {
     implementation("io.github.jadarma.aockt:aockt-core:$aocktVersion")
     testImplementation("io.github.jadarma.aockt:aockt-test:$aocktVersion")
-    testImplementation("io.kotest:kotest-runner-junit5:5.7.1")
+    testImplementation("io.kotest:kotest-runner-junit5:5.8.1")
 }
 
 tasks.test {

--- a/aockt-test/build.gradle.kts
+++ b/aockt-test/build.gradle.kts
@@ -5,6 +5,6 @@ plugins {
 dependencies {
     api(project(":aockt-core"))
     implementation(libs.kotlin.reflect)
-    implementation(libs.kotest.engine)
+    implementation(libs.kotest.api)
     implementation(libs.kotest.assertions)
 }

--- a/aockt-test/src/main/kotlin/io/github/jadarma/aockt/test/AdventSpec.kt
+++ b/aockt-test/src/main/kotlin/io/github/jadarma/aockt/test/AdventSpec.kt
@@ -13,16 +13,15 @@ import io.github.jadarma.aockt.test.internal.MissingNoArgConstructorException
 import io.github.jadarma.aockt.test.internal.PuzzleAnswer
 import io.github.jadarma.aockt.test.internal.PuzzleTestData
 import io.github.jadarma.aockt.test.internal.TestData
+import io.github.jadarma.aockt.test.internal.configuration
 import io.github.jadarma.aockt.test.internal.id
 import io.github.jadarma.aockt.test.internal.partFunction
 import io.github.jadarma.aockt.test.internal.solutionToPart
 import io.kotest.assertions.failure
 import io.kotest.assertions.withClue
 import io.kotest.common.ExperimentalKotest
-import io.kotest.common.KotestInternal
 import io.kotest.core.concurrency.CoroutineDispatcherFactory
 import io.kotest.core.config.ProjectConfiguration
-import io.kotest.core.config.configuration
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCaseOrder
@@ -157,18 +156,10 @@ public abstract class AdventSpec<T : Solution>(
             tags = if (expensive) setOf(Expensive) else emptySet(),
         ) {
             val partFunction = solution.partFunction(part)
-            @OptIn(KotestInternal::class)
-            val extension = configuration.registry.all()
-                .filterIsInstance<AocKtExtension>()
-                .firstOrNull()
 
-            val execMode = executionMode
-                ?: extension?.executionMode
-                ?: AocKtExtension.defaultExecutionMode
-
-            val maxEfficientDuration = efficiencyBenchmark
-                ?: extension?.efficiencyBenchmark
-                ?: AocKtExtension.defaultEfficiencyBenchmark
+            val config = configuration()
+            val execMode = executionMode ?: config.executionMode
+            val maxEfficientDuration = efficiencyBenchmark ?: config.efficiencyBenchmark
 
             if (examples != null) {
                 context("Validates the examples").config(enabled = execMode != ExecMode.SkipExamples) {

--- a/aockt-test/src/main/kotlin/io/github/jadarma/aockt/test/AdventSpec.kt
+++ b/aockt-test/src/main/kotlin/io/github/jadarma/aockt/test/AdventSpec.kt
@@ -19,6 +19,7 @@ import io.github.jadarma.aockt.test.internal.solutionToPart
 import io.kotest.assertions.failure
 import io.kotest.assertions.withClue
 import io.kotest.common.ExperimentalKotest
+import io.kotest.common.KotestInternal
 import io.kotest.core.concurrency.CoroutineDispatcherFactory
 import io.kotest.core.config.ProjectConfiguration
 import io.kotest.core.config.configuration
@@ -156,6 +157,7 @@ public abstract class AdventSpec<T : Solution>(
             tags = if (expensive) setOf(Expensive) else emptySet(),
         ) {
             val partFunction = solution.partFunction(part)
+            @OptIn(KotestInternal::class)
             val extension = configuration.registry.all()
                 .filterIsInstance<AocKtExtension>()
                 .firstOrNull()

--- a/aockt-test/src/main/kotlin/io/github/jadarma/aockt/test/AocKtExtension.kt
+++ b/aockt-test/src/main/kotlin/io/github/jadarma/aockt/test/AocKtExtension.kt
@@ -2,16 +2,11 @@ package io.github.jadarma.aockt.test
 
 import io.github.jadarma.aockt.test.internal.AocktDisplayNameFormatter
 import io.github.jadarma.aockt.test.internal.ConfigurationException
-import io.kotest.core.config.ProjectConfiguration
+import io.kotest.common.KotestInternal
 import io.kotest.core.extensions.DisplayNameFormatterExtension
-import io.kotest.core.extensions.Extension
 import io.kotest.core.extensions.ProjectExtension
 import io.kotest.core.names.DisplayNameFormatter
 import io.kotest.core.project.ProjectContext
-import io.kotest.engine.config.ConfigManager
-import io.kotest.engine.config.detectAbstractProjectConfigsJVM
-import io.kotest.engine.config.loadProjectConfigFromClassnameJVM
-import io.kotest.engine.test.names.DefaultDisplayNameFormatter
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -48,48 +43,7 @@ public class AocKtExtension(
     internal val executionMode: ExecMode = defaultExecutionMode,
 ) : ProjectExtension, DisplayNameFormatterExtension {
 
-    @Suppress("ForbiddenComment")
-    // TODO: This is an experimental hack to enable properly configured fallbacks for formatting, but it currently
-    //       relies on internal APIs.
-    //       [Kotest#3679](https://github.com/kotest/kotest/issues/3679) tracks the feature request to work around this.
-    private val displayNameFormatter: DisplayNameFormatter by lazy {
-
-        // Get the materialized configuration. Unfortunately relies on internal APIs and has to be retested on every
-        // new release.
-        @Suppress("UnstableApiUsage")
-        val configuration: ProjectConfiguration = ConfigManager.initialize(ProjectConfiguration()) {
-            detectAbstractProjectConfigsJVM() + listOfNotNull(loadProjectConfigFromClassnameJVM())
-        }
-
-        // See if any other formatter extensions have been registered by the user.
-        val registeredFormatters: List<DisplayNameFormatterExtension> =
-            configuration
-                .registry.all()
-                .filterIsInstance<DisplayNameFormatterExtension>()
-                .filterNot { it is AocKtExtension }
-
-        // Get the fallback formatter, which is either the user provided one, or the default formatter based on the
-        // user-customised configuration.
-        val fallbackFormatter = registeredFormatters
-            .firstOrNull()
-            ?.formatter()
-            ?: DefaultDisplayNameFormatter(configuration)
-
-        // Unregister all other formatter extensions, so that Kotest's call of `getDisplayNameFormatter()` is
-        // guaranteed to return a reference to this extension.
-        // This is okay to do because we already have a reference to the fallback formatter, and formatting extensions
-        // are only used to retrieve it anyway.
-        registeredFormatters.forEach {
-            configuration.registry.remove(it as Extension)
-        }
-
-        // If custom AdventSpec formatting is not desired, return the fallback right away.
-        // Otherwise, wrap it in the custom formatter.
-        when (formatAdventSpecNames) {
-            false -> fallbackFormatter
-            true -> AocktDisplayNameFormatter(fallbackFormatter)
-        }
-    }
+    private val displayNameFormatter = AocktDisplayNameFormatter(disabled = formatAdventSpecNames.not())
 
     override fun formatter(): DisplayNameFormatter = displayNameFormatter
 
@@ -97,6 +51,7 @@ public class AocKtExtension(
         require(efficiencyBenchmark.isPositive()) { "The efficiency benchmark must be positive." }
     }
 
+    @OptIn(KotestInternal::class)
     override suspend fun interceptProject(context: ProjectContext, callback: suspend (ProjectContext) -> Unit) {
 
         // Only allow a single instance of AocKt extension to be registered per project.

--- a/aockt-test/src/main/kotlin/io/github/jadarma/aockt/test/AocKtExtension.kt
+++ b/aockt-test/src/main/kotlin/io/github/jadarma/aockt/test/AocKtExtension.kt
@@ -1,14 +1,17 @@
 package io.github.jadarma.aockt.test
 
+import io.github.jadarma.aockt.test.internal.AdventSpecConfig
 import io.github.jadarma.aockt.test.internal.AocktDisplayNameFormatter
-import io.github.jadarma.aockt.test.internal.ConfigurationException
-import io.kotest.common.KotestInternal
 import io.kotest.core.extensions.DisplayNameFormatterExtension
-import io.kotest.core.extensions.ProjectExtension
+import io.kotest.core.extensions.TestCaseExtension
 import io.kotest.core.names.DisplayNameFormatter
-import io.kotest.core.project.ProjectContext
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * A Kotest Extension to configure the AdventSpecs.
@@ -23,14 +26,14 @@ import kotlin.time.Duration.Companion.seconds
  *
  * @param formatAdventSpecNames Whether to pretty print the names of the AdventSpec in the test output.
  *   Enabled by default.
- * @property efficiencyBenchmark What is the maximum runtime a solution can have while being considered efficient by
+ * @param efficiencyBenchmark What is the maximum runtime a solution can have while being considered efficient by
  *   the time tests.
  *   Can be overridden on a per-test basis.
  *   According to the AoC website, all solutions *should* be completable in 15 seconds regardless of hardware.
  *   You may decrease this value for an increased challenge though do be aware of fluctuations in execution time due to
  *   JVM warmup.
  *   Default is fifteen seconds.
- * @property executionMode The default execution mode for puzzle part definitions.
+ * @param executionMode The default execution mode for puzzle part definitions.
  *   Can be overridden on a per-test basis.
  *   If set to `ExamplesOnly`, does not run against the true puzzle input even if present.
  *   Useful when running the project with encrypted inputs (e.g. running a clone of someone else's solution repo).
@@ -39,39 +42,24 @@ import kotlin.time.Duration.Companion.seconds
  */
 public class AocKtExtension(
     private val formatAdventSpecNames: Boolean = true,
-    internal val efficiencyBenchmark: Duration = defaultEfficiencyBenchmark,
-    internal val executionMode: ExecMode = defaultExecutionMode,
-) : ProjectExtension, DisplayNameFormatterExtension {
+    efficiencyBenchmark: Duration = AdventSpecConfig.Default.efficiencyBenchmark,
+    executionMode: ExecMode = AdventSpecConfig.Default.executionMode,
+) : TestCaseExtension, DisplayNameFormatterExtension, AbstractCoroutineContextElement(Key) {
+
+    internal val configuration: AdventSpecConfig = AdventSpecConfig(efficiencyBenchmark, executionMode)
 
     private val displayNameFormatter = AocktDisplayNameFormatter(disabled = formatAdventSpecNames.not())
 
     override fun formatter(): DisplayNameFormatter = displayNameFormatter
 
-    init {
-        require(efficiencyBenchmark.isPositive()) { "The efficiency benchmark must be positive." }
-    }
-
-    @OptIn(KotestInternal::class)
-    override suspend fun interceptProject(context: ProjectContext, callback: suspend (ProjectContext) -> Unit) {
-
-        // Only allow a single instance of AocKt extension to be registered per project.
-        checkConfig(context.configuration.registry.all().filterIsInstance<AocKtExtension>().first() === this) {
-            "AocKtExtension was registered twice. Only one instance is allowed."
+    override suspend fun intercept(testCase: TestCase, execute: suspend (TestCase) -> TestResult): TestResult =
+        if (testCase.spec is AdventSpec<*>) {
+            withContext(currentCoroutineContext() + this) { execute(testCase) }
+        } else {
+            execute(testCase)
         }
 
-        // Continue running the project.
-        callback(context)
-    }
-
-    internal companion object {
-
-        internal val defaultEfficiencyBenchmark: Duration = 15.seconds
-        internal val defaultExecutionMode: ExecMode = ExecMode.All
-
-        private fun checkConfig(condition: Boolean, lazyMessage: () -> String) {
-            if (!condition) throw ConfigurationException(lazyMessage())
-        }
-    }
+    internal companion object Key : CoroutineContext.Key<AocKtExtension>
 }
 
 public enum class ExecMode {

--- a/aockt-test/src/main/kotlin/io/github/jadarma/aockt/test/internal/AdventSpecConfig.kt
+++ b/aockt-test/src/main/kotlin/io/github/jadarma/aockt/test/internal/AdventSpecConfig.kt
@@ -1,0 +1,45 @@
+package io.github.jadarma.aockt.test.internal
+
+import io.github.jadarma.aockt.test.AdventSpec
+import io.github.jadarma.aockt.test.AocKtExtension
+import io.github.jadarma.aockt.test.ExecMode
+import kotlinx.coroutines.currentCoroutineContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Holds configurations for how an [AdventSpec] should behave when running tests.
+ *
+ * @property efficiencyBenchmark What is the maximum runtime a solution can have while being considered efficient by
+ *                               the time tests.
+ * @property executionMode       The default execution mode for puzzle part definitions.
+ */
+internal data class AdventSpecConfig(
+    val efficiencyBenchmark: Duration,
+    val executionMode: ExecMode,
+) {
+    init {
+        if (efficiencyBenchmark.isPositive().not()) {
+            throw ConfigurationException("Efficiency benchmark must be a positive value, but was: $efficiencyBenchmark")
+        }
+    }
+
+    companion object {
+        /** Sane defaults. */
+        val Default: AdventSpecConfig = AdventSpecConfig(
+            efficiencyBenchmark = 15.seconds,
+            executionMode = ExecMode.All,
+        )
+    }
+}
+
+/**
+ * Retrieves the [AdventSpecConfig] for this spec from the test runner coroutine.
+ * If an [AocKtExtension] has been registered, use the user-provided configuration.
+ * Otherwise, returns the sane defaults.
+ */
+@Suppress("UnusedReceiverParameter")
+internal suspend fun AdventSpec<*>.configuration(): AdventSpecConfig =
+    currentCoroutineContext()[AocKtExtension.Key]
+        ?.configuration
+        ?: AdventSpecConfig.Default

--- a/aockt-test/src/main/kotlin/io/github/jadarma/aockt/test/internal/AocktDisplayNameFormatter.kt
+++ b/aockt-test/src/main/kotlin/io/github/jadarma/aockt/test/internal/AocktDisplayNameFormatter.kt
@@ -3,24 +3,25 @@ package io.github.jadarma.aockt.test.internal
 import io.github.jadarma.aockt.test.AdventDay
 import io.github.jadarma.aockt.test.AdventSpec
 import io.kotest.core.names.DisplayNameFormatter
-import io.kotest.engine.test.names.DefaultDisplayNameFormatter
+import io.kotest.core.test.TestCase
 import io.kotest.mpp.annotation
 import kotlin.reflect.KClass
 import kotlin.reflect.full.isSubclassOf
 
-/**
- * A name formatter extension that adjusts the names of [AdventSpec]s with the info of their [AdventDay].
- * @param fallbackFormatter The formatter to use for test cases and non-advent specs.
- */
-internal class AocktDisplayNameFormatter(
-    private val fallbackFormatter: DisplayNameFormatter = DefaultDisplayNameFormatter(),
-) : DisplayNameFormatter by fallbackFormatter {
+/** A name formatter extension that adjusts the names of [AdventSpec]s with the info of their [AdventDay]. */
+internal class AocktDisplayNameFormatter(private val disabled: Boolean = false) : DisplayNameFormatter {
 
-    override fun format(kclass: KClass<*>): String {
+    // Test cases are not formatted.
+    override fun format(testCase: TestCase) = null
+
+    @Suppress("ReturnCount")
+    override fun format(kclass: KClass<*>): String? {
+        if (disabled) return null
+
         val annotation = kclass.annotation<AdventDay>()
 
         if (annotation == null || !kclass.isSubclassOf(AdventSpec::class)) {
-            return fallbackFormatter.format(kclass)
+            return null
         }
 
         return buildString {

--- a/aockt-test/src/main/kotlin/io/github/jadarma/aockt/test/internal/Exceptions.kt
+++ b/aockt-test/src/main/kotlin/io/github/jadarma/aockt/test/internal/Exceptions.kt
@@ -6,8 +6,7 @@ import io.github.jadarma.aockt.test.AdventDay
 import kotlin.reflect.KClass
 
 /** Base [Exception] type for all exceptions related to AocKt. */
-@Suppress("UnnecessaryAbstractClass")
-internal abstract class AocktException(message: String? = null, cause: Throwable? = null) : Exception(message, cause)
+internal sealed class AocktException(message: String? = null, cause: Throwable? = null) : Exception(message, cause)
 
 /** A general exception thrown upon a misconfiguration event. */
 internal class ConfigurationException(message: String? = null) : AocktException(message = message)

--- a/aockt-test/src/test/kotlin/io/github/jadarma/aockt/test/TestConfig.kt
+++ b/aockt-test/src/test/kotlin/io/github/jadarma/aockt/test/TestConfig.kt
@@ -6,7 +6,6 @@ import io.kotest.core.extensions.Extension
 import kotlin.time.Duration.Companion.milliseconds
 
 @Suppress("Unused")
-@ExperimentalKotest
 object TestConfig : AbstractProjectConfig() {
 
     override fun extensions() = listOf<Extension>(
@@ -18,5 +17,7 @@ object TestConfig : AbstractProjectConfig() {
 
     private val cores = Runtime.getRuntime().availableProcessors()
     override val parallelism: Int = cores
+
+    @ExperimentalKotest
     override val concurrentSpecs: Int = cores
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "1.9.23"       # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib
 detekt = "1.23.6"       # https://mvnrepository.com/artifact/io.gitlab.arturbosch.detekt/detekt-gradle-plugin
 dokka = "1.9.20"        # https://mvnrepository.com/artifact/org.jetbrains.dokka/dokka-gradle-plugin
-kotest = "5.7.2"        # https://mvnrepository.com/artifact/io.kotest/kotest-framework-engine
+kotest = "5.8.1"        # https://mvnrepository.com/artifact/io.kotest/kotest-framework-engine
 
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
@@ -10,7 +10,7 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 kotlin-plugin-jvm = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 detekt-plugin = { module = "io.gitlab.arturbosch.detekt:io.gitlab.arturbosch.detekt.gradle.plugin", version.ref = "detekt" }
 dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
-kotest-engine = { module = "io.kotest:kotest-framework-engine-jvm", version.ref = "kotest" }
+kotest-api = { module = "io.kotest:kotest-framework-api-jvm", version.ref = "kotest" }
 kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotest-assertions = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "kotest" }
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }


### PR DESCRIPTION
Kotest's recent 5.8.1 release includes a fix for kotest/kotest#3679 which allows for better extension configuration.

- Remove old voo-doo workaround for display name formatting.
- AdventSpecs no longer need an AocKtExtension to be registered, can use sane defaults.
- Inject config into test coroutine context via test extension.
- Remove the use of extension registry, which was an internal Kotest API.